### PR TITLE
[#4919] Chevah-related fixes in cryptography 2.2.2.

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -46,7 +46,7 @@ def _extra_compile_args(platform):
     When we drop support for CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 we can
     revisit this.
     """
-    if platform != "win32":
+    if not platform in [ "win32", "sunos5", "hp-ux11" ]:
         return ["-Wconversion", "-Wno-error=sign-conversion"]
     else:
         return []

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -143,6 +143,7 @@ void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *path,
 }
 
 void Cryptography_free_wrapper(void *ptr, const char *path, int line) {
-    return free(ptr);
+    free(ptr);
+    return;
 }
 """

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -256,8 +256,7 @@ int X509_get_signature_nid(const X509 *);
 
 const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *);
 
-/* in 1.1.0 becomes const ASN1_BIT_STRING, const X509_ALGOR */
-void X509_get0_signature(ASN1_BIT_STRING **, X509_ALGOR **, X509 *);
+void X509_get0_signature(const ASN1_BIT_STRING **, const X509_ALGOR **, const X509 *);
 
 long X509_get_version(X509 *);
 
@@ -340,7 +339,8 @@ void X509_REQ_get0_signature(const X509_REQ *, const ASN1_BIT_STRING **,
 CUSTOMIZATIONS = """
 /* Added in 1.0.2 beta but we need it in all versions now due to the great
    opaquing. */
-#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102 && \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 /* from x509/x_x509.c version 1.0.2 */
 void X509_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
                          const X509 *x)
@@ -388,9 +388,11 @@ X509_REVOKED *Cryptography_X509_REVOKED_dup(X509_REVOKED *rev) {
    opaquing. */
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
 
+#if (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 int X509_up_ref(X509 *x) {
    return CRYPTO_add(&x->references, 1, CRYPTO_LOCK_X509);
 }
+#endif
 
 const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *x)
 {

--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -204,7 +204,7 @@ int sk_X509_OBJECT_num(Cryptography_STACK_OF_X509_OBJECT *);
 X509_OBJECT *sk_X509_OBJECT_value(Cryptography_STACK_OF_X509_OBJECT *, int);
 X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *);
 Cryptography_STACK_OF_X509_OBJECT *X509_STORE_get0_objects(X509_STORE *);
-X509 *X509_OBJECT_get0_X509(X509_OBJECT *);
+X509 *X509_OBJECT_get0_X509(const X509_OBJECT *);
 int X509_OBJECT_get_type(const X509_OBJECT *);
 
 /* added in 1.1.0 */
@@ -220,14 +220,11 @@ static const long Cryptography_HAS_102_VERIFICATION_ERROR_CODES = 1;
 static const long Cryptography_HAS_102_VERIFICATION_PARAMS = 1;
 #else
 static const long Cryptography_HAS_102_VERIFICATION_ERROR_CODES = 0;
+#if LIBRESSL_VERSION_NUMBER >= 0x2070000fL
+static const long Cryptography_HAS_102_VERIFICATION_PARAMS = 1;
+#else
 static const long Cryptography_HAS_102_VERIFICATION_PARAMS = 0;
 
-static const long X509_V_ERR_SUITE_B_INVALID_VERSION = 0;
-static const long X509_V_ERR_SUITE_B_INVALID_ALGORITHM = 0;
-static const long X509_V_ERR_SUITE_B_INVALID_CURVE = 0;
-static const long X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM = 0;
-static const long X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED = 0;
-static const long X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256 = 0;
 /* These 3 defines are unavailable in LibreSSL 2.5.x, but may be added
    in the future... */
 #ifndef X509_V_ERR_HOSTNAME_MISMATCH
@@ -240,12 +237,6 @@ static const long X509_V_ERR_EMAIL_MISMATCH = 0;
 static const long X509_V_ERR_IP_ADDRESS_MISMATCH = 0;
 #endif
 
-/* X509_V_FLAG_TRUSTED_FIRST is also new in 1.0.2+, but it is added separately
-   below because it shows up in some earlier 3rd party OpenSSL packages. */
-static const long X509_V_FLAG_SUITEB_128_LOS_ONLY = 0;
-static const long X509_V_FLAG_SUITEB_192_LOS = 0;
-static const long X509_V_FLAG_SUITEB_128_LOS = 0;
-
 int (*X509_VERIFY_PARAM_set1_host)(X509_VERIFY_PARAM *, const char *,
                                    size_t) = NULL;
 int (*X509_VERIFY_PARAM_set1_email)(X509_VERIFY_PARAM *, const char *,
@@ -255,6 +246,19 @@ int (*X509_VERIFY_PARAM_set1_ip)(X509_VERIFY_PARAM *, const unsigned char *,
 int (*X509_VERIFY_PARAM_set1_ip_asc)(X509_VERIFY_PARAM *, const char *) = NULL;
 void (*X509_VERIFY_PARAM_set_hostflags)(X509_VERIFY_PARAM *,
                                         unsigned int) = NULL;
+#endif
+
+static const long X509_V_ERR_SUITE_B_INVALID_VERSION = 0;
+static const long X509_V_ERR_SUITE_B_INVALID_ALGORITHM = 0;
+static const long X509_V_ERR_SUITE_B_INVALID_CURVE = 0;
+static const long X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM = 0;
+static const long X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED = 0;
+static const long X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256 = 0;
+/* X509_V_FLAG_TRUSTED_FIRST is also new in 1.0.2+, but it is added separately
+   below because it shows up in some earlier 3rd party OpenSSL packages. */
+static const long X509_V_FLAG_SUITEB_128_LOS_ONLY = 0;
+static const long X509_V_FLAG_SUITEB_192_LOS = 0;
+static const long X509_V_FLAG_SUITEB_128_LOS = 0;
 #endif
 
 /* OpenSSL 1.0.2+ or Solaris's backport */
@@ -292,7 +296,7 @@ X509 *X509_STORE_CTX_get0_cert(X509_STORE_CTX *ctx)
     return ctx->cert;
 }
 
-X509 *X509_OBJECT_get0_X509(X509_OBJECT *x) {
+X509 *X509_OBJECT_get0_X509(const X509_OBJECT *x) {
     return x->data.x509;
 }
 #endif


### PR DESCRIPTION
Documented the changes in our `chevah`, `chevah2` and `chevah3` tarballs from http://pypi.chevah.com.

I'll try to upstream changes in `chevah` and `chevah3` in some form or another…

@adiroiban, just a FYI.